### PR TITLE
Fix(#1): Navigate to right origin page when finishing set record

### DIFF
--- a/lib/src/presentation/containers/set_owe_record/set_owe_record_amount_step_container.dart
+++ b/lib/src/presentation/containers/set_owe_record/set_owe_record_amount_step_container.dart
@@ -11,12 +11,14 @@ class SetOweRecordAmountStepContainer extends StatelessWidget {
   final Debtor recordDebtor;
   final OweType oweRecordType;
   final OweRecordDraft? oweRecordDraftToEdit;
+  final bool fromDebtorPage;
 
   const SetOweRecordAmountStepContainer({
     super.key,
     required this.recordDebtor,
     required this.oweRecordType,
     this.oweRecordDraftToEdit,
+    required this.fromDebtorPage,
   });
 
   @override
@@ -32,6 +34,7 @@ class SetOweRecordAmountStepContainer extends StatelessWidget {
         recordDebtor: recordDebtor,
         oweRecordType: oweRecordType,
         oweRecordDraftToEdit: oweRecordDraftToEdit,
+        fromDebtorPage: fromDebtorPage,
       ),
     );
   }

--- a/lib/src/presentation/containers/set_owe_record/set_owe_record_debtor_selection_container.dart
+++ b/lib/src/presentation/containers/set_owe_record/set_owe_record_debtor_selection_container.dart
@@ -9,11 +9,13 @@ import 'package:owe_me/src/presentation/pages/set_owe_record/set_owe_record_debt
 class SetOweRecordDebtorSelectionContainer extends StatelessWidget {
   final OweType oweRecordType;
   final OweRecordDraft? oweRecordDraftToEdit;
+  final bool fromDebtorPage;
 
   const SetOweRecordDebtorSelectionContainer({
     super.key,
     required this.oweRecordType,
     this.oweRecordDraftToEdit,
+    required this.fromDebtorPage,
   });
 
   @override
@@ -26,6 +28,7 @@ class SetOweRecordDebtorSelectionContainer extends StatelessWidget {
       child: SetOweRecordDebtorSelectionPage(
         oweRecordType: oweRecordType,
         oweRecordDraftToEdit: oweRecordDraftToEdit,
+        fromDebtorPage: fromDebtorPage,
       ),
     );
   }

--- a/lib/src/presentation/containers/set_owe_record/set_owe_record_description_step_container.dart
+++ b/lib/src/presentation/containers/set_owe_record/set_owe_record_description_step_container.dart
@@ -9,11 +9,13 @@ import 'package:owe_me/src/presentation/pages/set_owe_record/set_owe_record_desc
 class SetOweRecordDescriptionStepContainer extends StatelessWidget {
   final OweRecordDraft oweRecordDraft;
   final Debtor recordDebtor;
+  final bool fromDebtorPage;
 
   const SetOweRecordDescriptionStepContainer({
     super.key,
     required this.oweRecordDraft,
     required this.recordDebtor,
+    required this.fromDebtorPage,
   });
 
   @override
@@ -26,7 +28,9 @@ class SetOweRecordDescriptionStepContainer extends StatelessWidget {
             recordDebtor: recordDebtor,
           ),
         ),
-      child: const SetOweRecordDescriptionStepPage(),
+      child: SetOweRecordDescriptionStepPage(
+        fromDebtorPage: fromDebtorPage,
+      ),
     );
   }
 }

--- a/lib/src/presentation/containers/set_owe_record/set_owe_record_info_review_container.dart
+++ b/lib/src/presentation/containers/set_owe_record/set_owe_record_info_review_container.dart
@@ -9,11 +9,13 @@ import 'package:owe_me/src/presentation/pages/set_owe_record/set_owe_record_info
 class SetOweRecordInfoReviewContainer extends StatelessWidget {
   final Debtor recordDebtor;
   final OweRecordDraft oweRecordDraft;
+  final bool fromDebtorPage;
 
   const SetOweRecordInfoReviewContainer({
     super.key,
     required this.recordDebtor,
     required this.oweRecordDraft,
+    required this.fromDebtorPage,
   });
 
   @override
@@ -29,6 +31,7 @@ class SetOweRecordInfoReviewContainer extends StatelessWidget {
       child: SetOweRecordInfoReviewPage(
         recordDebtor: recordDebtor,
         oweRecordDraft: oweRecordDraft,
+        fromDebtorPage: fromDebtorPage,
       ),
     );
   }

--- a/lib/src/presentation/containers/set_payment_record/set_payment_record_debtor_selection_container.dart
+++ b/lib/src/presentation/containers/set_payment_record/set_payment_record_debtor_selection_container.dart
@@ -7,10 +7,12 @@ import 'package:owe_me/src/presentation/pages/set_payment_record/set_payment_rec
 
 class SetPaymentRecordDebtorSelectionContainer extends StatelessWidget {
   final PaymentRecordDraft? paymentRecordDraftToEdit;
+  final bool fromDebtorPage;
 
   const SetPaymentRecordDebtorSelectionContainer({
     super.key,
     this.paymentRecordDraftToEdit,
+    required this.fromDebtorPage,
   });
 
   @override
@@ -22,6 +24,7 @@ class SetPaymentRecordDebtorSelectionContainer extends StatelessWidget {
         ),
       child: SetPaymentRecordDebtorSelectionPage(
         paymentRecordDraftToEdit: paymentRecordDraftToEdit,
+        fromDebtorPage: fromDebtorPage,
       ),
     );
   }

--- a/lib/src/presentation/containers/set_payment_record/set_payment_record_info_review_container.dart
+++ b/lib/src/presentation/containers/set_payment_record/set_payment_record_info_review_container.dart
@@ -9,11 +9,13 @@ import 'package:owe_me/src/presentation/pages/set_payment_record/set_payment_rec
 class SetPaymentRecordInfoReviewContainer extends StatelessWidget {
   final Debtor recordDebtor;
   final PaymentRecordDraft paymentRecordDraft;
+  final bool fromDebtorPage;
 
   const SetPaymentRecordInfoReviewContainer({
     super.key,
     required this.recordDebtor,
     required this.paymentRecordDraft,
+    required this.fromDebtorPage,
   });
 
   @override
@@ -29,6 +31,7 @@ class SetPaymentRecordInfoReviewContainer extends StatelessWidget {
       child: SetPaymentRecordInfoReviewPage(
         recordDebtor: recordDebtor,
         paymentRecordDraft: paymentRecordDraft,
+        fromDebtorPage: fromDebtorPage,
       ),
     );
   }

--- a/lib/src/presentation/pages/set_owe_record/set_owe_record_amount_step_page.dart
+++ b/lib/src/presentation/pages/set_owe_record/set_owe_record_amount_step_page.dart
@@ -15,12 +15,14 @@ class SetOweRecordAmountStepPage extends StatelessWidget {
   final Debtor recordDebtor;
   final OweType oweRecordType;
   final OweRecordDraft? oweRecordDraftToEdit;
+  final bool fromDebtorPage;
 
   const SetOweRecordAmountStepPage({
     super.key,
     required this.recordDebtor,
     required this.oweRecordType,
     this.oweRecordDraftToEdit,
+    required this.fromDebtorPage,
   });
 
   void _listen(BuildContext context, SetOweRecordAmountStepState state) {
@@ -48,6 +50,7 @@ class SetOweRecordAmountStepPage extends StatelessWidget {
         builder: (context) => SetOweRecordInfoReviewContainer(
           oweRecordDraft: oweRecordDraftToEdit!.copyWith(amount: amount),
           recordDebtor: recordDebtor,
+          fromDebtorPage: fromDebtorPage,
         ),
       ),
     );
@@ -70,6 +73,7 @@ class SetOweRecordAmountStepPage extends StatelessWidget {
             amount: amount,
           ),
           recordDebtor: recordDebtor,
+          fromDebtorPage: fromDebtorPage,
         ),
       ),
     );

--- a/lib/src/presentation/pages/set_owe_record/set_owe_record_date_step_page.dart
+++ b/lib/src/presentation/pages/set_owe_record/set_owe_record_date_step_page.dart
@@ -10,11 +10,13 @@ import 'package:owe_me/src/presentation/widgets/shared/app_date_picker.dart';
 class SetOweRecordDateStepPage extends StatefulWidget {
   final OweRecordDraft oweRecordDraft;
   final Debtor recordDebtor;
+  final bool fromDebtorPage;
 
   const SetOweRecordDateStepPage({
     super.key,
     required this.oweRecordDraft,
     required this.recordDebtor,
+    required this.fromDebtorPage,
   });
 
   @override
@@ -80,6 +82,7 @@ class _SetOweRecordDateStepPageState extends State<SetOweRecordDateStepPage> {
               oweRecordDraft: _updatedOweRecordDraft,
               recordDebtor: widget.recordDebtor,
               isEdition: _isEdition,
+              fromDebtorPage: widget.fromDebtorPage,
             ),
           ),
         ],

--- a/lib/src/presentation/pages/set_owe_record/set_owe_record_debtor_selection_page.dart
+++ b/lib/src/presentation/pages/set_owe_record/set_owe_record_debtor_selection_page.dart
@@ -13,11 +13,13 @@ import 'package:owe_me/src/presentation/widgets/set_owe_record/debtor_selection_
 class SetOweRecordDebtorSelectionPage extends StatelessWidget {
   final OweType oweRecordType;
   final OweRecordDraft? oweRecordDraftToEdit;
+  final bool fromDebtorPage;
 
   const SetOweRecordDebtorSelectionPage({
     super.key,
     required this.oweRecordType,
     required this.oweRecordDraftToEdit,
+    required this.fromDebtorPage,
   });
 
   void _handleNavigationOnDebtorSelected(BuildContext context, Debtor selectedDebtor) {
@@ -34,6 +36,7 @@ class SetOweRecordDebtorSelectionPage extends StatelessWidget {
         builder: (context) => SetOweRecordAmountStepContainer(
           recordDebtor: selectedDebtor,
           oweRecordType: oweRecordType,
+          fromDebtorPage: fromDebtorPage,
         ),
       ),
     );
@@ -46,6 +49,7 @@ class SetOweRecordDebtorSelectionPage extends StatelessWidget {
         builder: (context) => SetOweRecordInfoReviewContainer(
           oweRecordDraft: oweRecordDraftToEdit!,
           recordDebtor: selectedDebtor,
+          fromDebtorPage: fromDebtorPage,
         ),
       ),
     );

--- a/lib/src/presentation/pages/set_owe_record/set_owe_record_description_step_page.dart
+++ b/lib/src/presentation/pages/set_owe_record/set_owe_record_description_step_page.dart
@@ -8,8 +8,11 @@ import 'package:owe_me/src/core/presentation/design_system/app_text_styles.dart'
 import 'package:owe_me/src/presentation/widgets/set_owe_record/description_step_page/set_owe_record_description_step_body.dart';
 
 class SetOweRecordDescriptionStepPage extends StatelessWidget {
+  final bool fromDebtorPage;
+
   const SetOweRecordDescriptionStepPage({
     super.key,
+    required this.fromDebtorPage,
   });
 
   void _listen(BuildContext context, SetOweRecordDescriptionStepState state) {
@@ -40,6 +43,7 @@ class SetOweRecordDescriptionStepPage extends StatelessWidget {
         builder: (context) => SetOweRecordInfoReviewContainer(
           oweRecordDraft: state.oweRecordDraft,
           recordDebtor: state.recordDebtor,
+          fromDebtorPage: fromDebtorPage,
         ),
       ),
     );
@@ -59,6 +63,7 @@ class SetOweRecordDescriptionStepPage extends StatelessWidget {
         builder: (context) => SetOweRecordDateStepPage(
           oweRecordDraft: state.oweRecordDraft,
           recordDebtor: state.recordDebtor,
+          fromDebtorPage: fromDebtorPage,
         ),
       ),
     );

--- a/lib/src/presentation/pages/set_owe_record/set_owe_record_info_review_page.dart
+++ b/lib/src/presentation/pages/set_owe_record/set_owe_record_info_review_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:owe_me/src/core/presentation/extensions/owe_type_ui_extensions.dart';
 import 'package:owe_me/src/core/presentation/extensions/string_extensions.dart';
+import 'package:owe_me/src/presentation/containers/debtor_container.dart';
 import 'package:owe_me/src/presentation/drafts/owe_record_draft.dart';
 import 'package:owe_me/src/domain/entities/debtor.dart';
 import 'package:owe_me/src/presentation/blocs/set_owe_record/info_review/set_owe_record_info_review_bloc.dart';
@@ -14,11 +15,13 @@ import 'package:owe_me/src/presentation/widgets/set_owe_record/info_review_page/
 class SetOweRecordInfoReviewPage extends StatelessWidget {
   final OweRecordDraft oweRecordDraft;
   final Debtor recordDebtor;
+  final bool fromDebtorPage;
 
   const SetOweRecordInfoReviewPage({
     super.key,
     required this.oweRecordDraft,
     required this.recordDebtor,
+    required this.fromDebtorPage,
   });
 
   void _listen(
@@ -41,6 +44,13 @@ class SetOweRecordInfoReviewPage extends StatelessWidget {
         ),
         (route) => false,
       );
+      if (fromDebtorPage) {
+        Navigator.of(context).push(
+          MaterialPageRoute(
+            builder: (context) => DebtorContainer(debtor: recordDebtor),
+          ),
+        );
+      }
     } else if (state is SetOweRecordInfoReviewError) {
       ScaffoldMessenger.of(context)
         ..hideCurrentSnackBar()
@@ -77,6 +87,7 @@ class SetOweRecordInfoReviewPage extends StatelessWidget {
                 child: SetOweRecordInfoReviewCard(
                   oweRecordDraft: oweRecordDraft,
                   recordDebtor: recordDebtor,
+                  fromDebtorPage: fromDebtorPage,
                 ),
               ),
             ),

--- a/lib/src/presentation/pages/set_payment_record/set_payment_record_debtor_selection_page.dart
+++ b/lib/src/presentation/pages/set_payment_record/set_payment_record_debtor_selection_page.dart
@@ -2,8 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:owe_me/src/domain/entities/debtor.dart';
 import 'package:owe_me/src/presentation/blocs/debtor_selection/debtor_selection_bloc.dart';
+import 'package:owe_me/src/presentation/containers/set_payment_record/set_payment_record_info_review_container.dart';
 import 'package:owe_me/src/presentation/drafts/payment_record_draft.dart';
-import 'package:owe_me/src/presentation/pages/set_payment_record/set_payment_record_info_review_page.dart';
 import 'package:owe_me/src/presentation/pages/set_payment_record/set_payment_record_page.dart';
 import 'package:owe_me/src/core/presentation/design_system/app_colors.dart';
 import 'package:owe_me/src/core/presentation/design_system/app_text_styles.dart';
@@ -11,10 +11,12 @@ import 'package:owe_me/src/presentation/widgets/set_payment_record/debtor_select
 
 class SetPaymentRecordDebtorSelectionPage extends StatelessWidget {
   final PaymentRecordDraft? paymentRecordDraftToEdit;
+  final bool fromDebtorPage;
 
   const SetPaymentRecordDebtorSelectionPage({
     super.key,
     this.paymentRecordDraftToEdit,
+    required this.fromDebtorPage,
   });
 
   void _handleNavigationOnDebtorSelected(BuildContext context, Debtor selectedDebtor) {
@@ -29,9 +31,10 @@ class SetPaymentRecordDebtorSelectionPage extends StatelessWidget {
     _popCurrentEditDebtorPageAndPreviousInfoReviewPage(context);
     Navigator.of(context).push(
       MaterialPageRoute(
-        builder: (context) => SetPaymentRecordInfoReviewPage(
+        builder: (context) => SetPaymentRecordInfoReviewContainer(
           paymentRecordDraft: paymentRecordDraftToEdit!,
           recordDebtor: selectedDebtor,
+          fromDebtorPage: fromDebtorPage,
         ),
       ),
     );
@@ -47,6 +50,7 @@ class SetPaymentRecordDebtorSelectionPage extends StatelessWidget {
       MaterialPageRoute(
         builder: (context) => SetPaymentRecordPage(
           recordDebtor: selectedDebtor,
+          fromDebtorPage: fromDebtorPage,
         ),
       ),
     );

--- a/lib/src/presentation/pages/set_payment_record/set_payment_record_info_review_page.dart
+++ b/lib/src/presentation/pages/set_payment_record/set_payment_record_info_review_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:owe_me/src/domain/entities/debtor.dart';
 import 'package:owe_me/src/presentation/blocs/set_payment_record/info_review/set_payment_record_info_review_bloc.dart';
+import 'package:owe_me/src/presentation/containers/debtor_container.dart';
 import 'package:owe_me/src/presentation/containers/home_container.dart';
 import 'package:owe_me/src/presentation/drafts/payment_record_draft.dart';
 import 'package:owe_me/src/core/presentation/design_system/app_colors.dart';
@@ -12,11 +13,13 @@ import 'package:owe_me/src/presentation/widgets/set_payment_record/info_review/s
 class SetPaymentRecordInfoReviewPage extends StatelessWidget {
   final PaymentRecordDraft paymentRecordDraft;
   final Debtor recordDebtor;
+  final bool fromDebtorPage;
 
   const SetPaymentRecordInfoReviewPage({
     super.key,
     required this.paymentRecordDraft,
     required this.recordDebtor,
+    required this.fromDebtorPage,
   });
 
   void _listen(
@@ -36,6 +39,13 @@ class SetPaymentRecordInfoReviewPage extends StatelessWidget {
         ),
         (route) => false,
       );
+      if (fromDebtorPage) {
+        Navigator.of(context).push(
+          MaterialPageRoute(
+            builder: (context) => DebtorContainer(debtor: recordDebtor),
+          ),
+        );
+      }
     } else if (state is SetPaymentRecordInfoReviewError) {
       ScaffoldMessenger.of(context)
         ..hideCurrentSnackBar()
@@ -65,6 +75,7 @@ class SetPaymentRecordInfoReviewPage extends StatelessWidget {
                 child: SetPaymentRecordInfoReviewCard(
                   paymentRecordDraft: paymentRecordDraft,
                   recordDebtor: recordDebtor,
+                  fromDebtorPage: fromDebtorPage,
                 ),
               ),
             ),

--- a/lib/src/presentation/pages/set_payment_record/set_payment_record_page.dart
+++ b/lib/src/presentation/pages/set_payment_record/set_payment_record_page.dart
@@ -14,11 +14,13 @@ import 'package:owe_me/src/presentation/widgets/shared/app_dropdown.dart';
 class SetPaymentRecordPage extends StatefulWidget {
   final PaymentRecordDraft? paymentRecordDraftToEdit;
   final Debtor recordDebtor;
+  final bool fromDebtorPage;
 
   const SetPaymentRecordPage({
     super.key,
     this.paymentRecordDraftToEdit,
     required this.recordDebtor,
+    required this.fromDebtorPage,
   });
 
   @override
@@ -32,7 +34,10 @@ class _SetPaymentRecordPageState extends State<SetPaymentRecordPage> {
   void initState() {
     super.initState();
     _paymentRecordDraft = widget.paymentRecordDraftToEdit ??
-        PaymentRecordDraft().copyWith(date: DateTime.now());
+        PaymentRecordDraft().copyWith(
+          date: DateTime.now(),
+          paymentMethod: PaymentMethod.cash,
+        );
   }
 
   void _onAmountChanged(Money amount) {
@@ -113,6 +118,7 @@ class _SetPaymentRecordPageState extends State<SetPaymentRecordPage> {
             child: SetPaymentRecordPrimaryButton(
               paymentRecordDraft: _paymentRecordDraft,
               recordDebtor: widget.recordDebtor,
+              fromDebtorPage: widget.fromDebtorPage,
             ),
           ),
         ],

--- a/lib/src/presentation/widgets/debtor_page/debtor_quick_action_section.dart
+++ b/lib/src/presentation/widgets/debtor_page/debtor_quick_action_section.dart
@@ -13,7 +13,10 @@ class DebtorQuickActionSection extends StatelessWidget {
   void _navigateToSetPaymentRecordPage(BuildContext context) {
     Navigator.of(context).push(
       MaterialPageRoute(
-        builder: (context) => SetPaymentRecordPage(recordDebtor: debtor),
+        builder: (context) => SetPaymentRecordPage(
+          recordDebtor: debtor,
+          fromDebtorPage: true,
+        ),
       ),
     );
   }
@@ -24,6 +27,7 @@ class DebtorQuickActionSection extends StatelessWidget {
         builder: (context) => SetOweRecordAmountStepContainer(
           recordDebtor: debtor,
           oweRecordType: OweType.credit,
+          fromDebtorPage: true,
         ),
       ),
     );
@@ -35,6 +39,7 @@ class DebtorQuickActionSection extends StatelessWidget {
         builder: (context) => SetOweRecordAmountStepContainer(
           recordDebtor: debtor,
           oweRecordType: OweType.debt,
+          fromDebtorPage: true,
         ),
       ),
     );

--- a/lib/src/presentation/widgets/home_page/debtor_list_item.dart
+++ b/lib/src/presentation/widgets/home_page/debtor_list_item.dart
@@ -28,7 +28,10 @@ class DebtorListItem extends StatelessWidget {
   void _navigateToSetPaymentRecordPage(BuildContext context) {
     Navigator.of(context).push(
       MaterialPageRoute(
-        builder: (context) => SetPaymentRecordPage(recordDebtor: debtor),
+        builder: (context) => SetPaymentRecordPage(
+          recordDebtor: debtor,
+          fromDebtorPage: false,
+        ),
       ),
     );
   }
@@ -39,6 +42,7 @@ class DebtorListItem extends StatelessWidget {
         builder: (context) => SetOweRecordAmountStepContainer(
           recordDebtor: debtor,
           oweRecordType: OweType.credit,
+          fromDebtorPage: false,
         ),
       ),
     );
@@ -50,6 +54,7 @@ class DebtorListItem extends StatelessWidget {
         builder: (context) => SetOweRecordAmountStepContainer(
           recordDebtor: debtor,
           oweRecordType: OweType.debt,
+          fromDebtorPage: false,
         ),
       ),
     );

--- a/lib/src/presentation/widgets/home_page/home_quick_action_buttons.dart
+++ b/lib/src/presentation/widgets/home_page/home_quick_action_buttons.dart
@@ -10,7 +10,9 @@ class HomeQuickActionButtons extends StatelessWidget {
   void _navigateToSetPaymentRecordPage(BuildContext context) {
     Navigator.of(context).push(
       MaterialPageRoute(
-        builder: (context) => const SetPaymentRecordDebtorSelectionContainer(),
+        builder: (context) => const SetPaymentRecordDebtorSelectionContainer(
+          fromDebtorPage: false,
+        ),
       ),
     );
   }
@@ -18,8 +20,10 @@ class HomeQuickActionButtons extends StatelessWidget {
   void _navigateToSetRecordDebtorSelectionPageAsCredit(BuildContext context) {
     Navigator.of(context).push(
       MaterialPageRoute(
-        builder: (context) =>
-            const SetOweRecordDebtorSelectionContainer(oweRecordType: OweType.credit),
+        builder: (context) => const SetOweRecordDebtorSelectionContainer(
+          oweRecordType: OweType.credit,
+          fromDebtorPage: false,
+        ),
       ),
     );
   }
@@ -27,8 +31,10 @@ class HomeQuickActionButtons extends StatelessWidget {
   void _navigateToSetRecordDebtorSelectionPageAsDebt(BuildContext context) {
     Navigator.of(context).push(
       MaterialPageRoute(
-        builder: (context) =>
-            const SetOweRecordDebtorSelectionContainer(oweRecordType: OweType.debt),
+        builder: (context) => const SetOweRecordDebtorSelectionContainer(
+          oweRecordType: OweType.debt,
+          fromDebtorPage: false,
+        ),
       ),
     );
   }

--- a/lib/src/presentation/widgets/set_owe_record/date_step_page/set_owe_record_date_step_primary_button.dart
+++ b/lib/src/presentation/widgets/set_owe_record/date_step_page/set_owe_record_date_step_primary_button.dart
@@ -8,12 +8,14 @@ class SetOweRecordDateStepPrimaryButton extends StatelessWidget {
   final OweRecordDraft oweRecordDraft;
   final Debtor recordDebtor;
   final bool isEdition;
+  final bool fromDebtorPage;
 
   const SetOweRecordDateStepPrimaryButton({
     super.key,
     required this.oweRecordDraft,
     required this.recordDebtor,
     required this.isEdition,
+    required this.fromDebtorPage,
   });
 
   void _finishEdition(BuildContext context) {
@@ -32,6 +34,7 @@ class SetOweRecordDateStepPrimaryButton extends StatelessWidget {
         builder: (context) => SetOweRecordInfoReviewContainer(
           oweRecordDraft: oweRecordDraft,
           recordDebtor: recordDebtor,
+          fromDebtorPage: fromDebtorPage,
         ),
       ),
     );

--- a/lib/src/presentation/widgets/set_owe_record/info_review_page/set_owe_record_info_review_card.dart
+++ b/lib/src/presentation/widgets/set_owe_record/info_review_page/set_owe_record_info_review_card.dart
@@ -14,11 +14,13 @@ import 'package:owe_me/src/core/presentation/design_system/app_text_styles.dart'
 class SetOweRecordInfoReviewCard extends StatelessWidget {
   final OweRecordDraft oweRecordDraft;
   final Debtor recordDebtor;
+  final bool fromDebtorPage;
 
   const SetOweRecordInfoReviewCard({
     super.key,
     required this.oweRecordDraft,
     required this.recordDebtor,
+    required this.fromDebtorPage,
   });
 
   //TODO check this
@@ -32,6 +34,7 @@ class SetOweRecordInfoReviewCard extends StatelessWidget {
         builder: (context) => SetOweRecordDebtorSelectionContainer(
           oweRecordDraftToEdit: oweRecordDraft,
           oweRecordType: oweRecordDraft.oweType,
+          fromDebtorPage: fromDebtorPage,
         ),
       ),
     );
@@ -44,6 +47,7 @@ class SetOweRecordInfoReviewCard extends StatelessWidget {
           oweRecordDraftToEdit: oweRecordDraft,
           recordDebtor: recordDebtor,
           oweRecordType: oweRecordDraft.oweType,
+          fromDebtorPage: fromDebtorPage,
         ),
       ),
     );
@@ -55,6 +59,7 @@ class SetOweRecordInfoReviewCard extends StatelessWidget {
         builder: (context) => SetOweRecordDescriptionStepContainer(
           oweRecordDraft: oweRecordDraft,
           recordDebtor: recordDebtor,
+          fromDebtorPage: fromDebtorPage,
         ),
       ),
     );
@@ -66,6 +71,7 @@ class SetOweRecordInfoReviewCard extends StatelessWidget {
         builder: (context) => SetOweRecordDateStepPage(
           oweRecordDraft: oweRecordDraft,
           recordDebtor: recordDebtor,
+          fromDebtorPage: fromDebtorPage,
         ),
       ),
     );

--- a/lib/src/presentation/widgets/set_payment_record/info_review/set_payment_record_info_review_card.dart
+++ b/lib/src/presentation/widgets/set_payment_record/info_review/set_payment_record_info_review_card.dart
@@ -12,11 +12,13 @@ import 'package:owe_me/src/core/presentation/design_system/app_text_styles.dart'
 class SetPaymentRecordInfoReviewCard extends StatelessWidget {
   final PaymentRecordDraft paymentRecordDraft;
   final Debtor recordDebtor;
+  final bool fromDebtorPage;
 
   const SetPaymentRecordInfoReviewCard({
     super.key,
     required this.paymentRecordDraft,
     required this.recordDebtor,
+    required this.fromDebtorPage,
   });
 
   //TODO check this
@@ -29,6 +31,7 @@ class SetPaymentRecordInfoReviewCard extends StatelessWidget {
       MaterialPageRoute(
         builder: (context) => SetPaymentRecordDebtorSelectionContainer(
           paymentRecordDraftToEdit: paymentRecordDraft,
+          fromDebtorPage: fromDebtorPage,
         ),
       ),
     );
@@ -40,6 +43,7 @@ class SetPaymentRecordInfoReviewCard extends StatelessWidget {
         builder: (context) => SetPaymentRecordPage(
           paymentRecordDraftToEdit: paymentRecordDraft,
           recordDebtor: recordDebtor,
+          fromDebtorPage: fromDebtorPage,
         ),
       ),
     );

--- a/lib/src/presentation/widgets/set_payment_record/page/set_payment_record_primary_button.dart
+++ b/lib/src/presentation/widgets/set_payment_record/page/set_payment_record_primary_button.dart
@@ -7,11 +7,13 @@ import 'package:owe_me/src/presentation/widgets/shared/app_elevated_button.dart'
 class SetPaymentRecordPrimaryButton extends StatelessWidget {
   final PaymentRecordDraft paymentRecordDraft;
   final Debtor recordDebtor;
+  final bool fromDebtorPage;
 
   const SetPaymentRecordPrimaryButton({
     super.key,
     required this.paymentRecordDraft,
     required this.recordDebtor,
+    required this.fromDebtorPage,
   });
 
   void _navigateToInfoReviewPage(BuildContext context) {
@@ -20,6 +22,7 @@ class SetPaymentRecordPrimaryButton extends StatelessWidget {
         builder: (context) => SetPaymentRecordInfoReviewContainer(
           paymentRecordDraft: paymentRecordDraft,
           recordDebtor: recordDebtor,
+          fromDebtorPage: fromDebtorPage,
         ),
       ),
     );


### PR DESCRIPTION
## Description
After setting payment, credit, or debt, navigate back to Debtor page when flow has started from there and navigate to Home page otherwise.

### Related issues
fixes #1 