### PR TITLE
Feat: limit and capitalize text inputs, add entity validation factories

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,10 @@
+{
+  "[dart]": {
+    "editor.defaultFormatter": "Dart-Code.dart-code",
+    "editor.formatOnSave": true,
+    "editor.codeActionsOnSave": {
+      "source.organizeImports": "explicit"
+    },
+    "editor.rulers": [80]
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,8 +61,14 @@ lib/src/
   calls it, AND form BLoCs call it directly for live per-keystroke validation — one
   shared source of truth. *Only* inline validation in the factory when it is a single
   check that is never used for live form validation.
-  - NOTE: `FavoriteDescription` currently validates inline and is the odd one out;
-    refactoring it to a rules class is a known cleanup (see Known work).
+- **Entity invariants (always-valid):** entities with validated fields are constructed
+  *only* via `create(...)` returning `Either<Failure, T>` (private constructor), and
+  `copyWith` re-validates the same way — it routes through `create` and also returns
+  `Either`, so **no mutation can produce a broken state** (`Debtor`, `OweRecord`).
+  Entities with no validated fields (e.g. `PaymentRecord`) keep a plain constructor —
+  no invariant to protect, so a factory would be ceremony. Entity-level failures (e.g.
+  `DebtorValidationFailure`) wrap the underlying rule failure as `Failure.cause` — a
+  diagnostic chain (like an exception's cause), not a UI message source.
 - **Failure → UI:** map domain failures to user-facing (Portuguese) strings via
   extensions in `presentation/validation_mappers/` (`uiMessage`). Keep UI strings out
   of the domain.
@@ -132,8 +138,6 @@ These are real items in the codebase (good candidates for paired tasks):
   catches everything → `DefaultFailure` (has `//TODO: handle specific Failures`):
   should map specific sqflite exceptions to domain failures.
 - `DebtorIdNotFoundFailure` is marked for renaming to something more specific.
-- Unify validation: refactor `FavoriteDescription` to a separated rules class to
-  match `RecordAmount`.
 - No DB migration strategy yet (schema version hardcoded to 1).
 - `provider` is in `pubspec.yaml` but unused.
 

--- a/lib/src/core/error/failures/failures.dart
+++ b/lib/src/core/error/failures/failures.dart
@@ -1,6 +1,7 @@
 abstract class Failure {
   final String message;
-  const Failure(this.message);
+  final Failure? cause;
+  const Failure(this.message, {this.cause});
 }
 
 class DefaultFailure extends Failure {

--- a/lib/src/data/adapters/debtor_adapter.dart
+++ b/lib/src/data/adapters/debtor_adapter.dart
@@ -1,3 +1,4 @@
+import 'package:owe_me/src/core/error/exceptions/mapping_exceptions.dart';
 import 'package:owe_me/src/data/models/debtor_model.dart';
 import 'package:owe_me/src/domain/entities/debtor.dart';
 import 'package:owe_me/src/domain/value_objects/money.dart';
@@ -14,10 +15,13 @@ class DebtorAdapter {
   }
 
   static Debtor toEntity(DebtorModel model) {
-    return Debtor(
+    return Debtor.create(
       id: model.id,
       nickname: model.nickname,
       totalDebt: Money(cents: model.totalDebtInCents),
-    );
+    ).getOrElse(() {
+      throw DataIntegrityException(
+          'Invalid DebtorModel data of id ${model.id}');
+    });
   }
 }

--- a/lib/src/data/adapters/owe_record_adapter.dart
+++ b/lib/src/data/adapters/owe_record_adapter.dart
@@ -28,12 +28,15 @@ class OweRecordAdapter {
           'Invalid amountInCents ${model.amountInCents} for OweRecordModel id ${model.id}');
     });
 
-    return OweRecord(
+    return OweRecord.create(
       id: model.id,
       amount: amount,
       description: model.description,
       date: DateTime.parse(model.date),
       oweType: OweType.values.byName(model.oweType),
-    );
+    ).getOrElse(() {
+      throw DataIntegrityException(
+          'Invalid description for OweRecordModel id ${model.id}');
+    });
   }
 }

--- a/lib/src/data/repositories/debtor_repository_impl.dart
+++ b/lib/src/data/repositories/debtor_repository_impl.dart
@@ -33,8 +33,10 @@ class DebtorRepositoryImpl implements DebtorRepository {
     try {
       final debtorModel = DebtorAdapter.toModel(debtor);
       final savedDebtorId = await _debtorDataSource.insertDebtor(debtorModel);
-      final savedDebtor = debtor.copyWith(id: savedDebtorId);
-      return Right(savedDebtor);
+      return debtor.copyWith(id: savedDebtorId).fold(
+            (failure) => Left(failure),
+            (savedDebtor) => Right(savedDebtor),
+          );
     } on Exception catch (e) {
       //TODO: handle specific Failures
       return Left(DefaultFailure(e.toString()));

--- a/lib/src/domain/entities/debtor.dart
+++ b/lib/src/domain/entities/debtor.dart
@@ -1,7 +1,7 @@
 import 'package:dartz/dartz.dart';
 import 'package:equatable/equatable.dart';
 import 'package:owe_me/src/domain/entities/monetary_record.dart';
-import 'package:owe_me/src/domain/validation/failures/nickname_validation_failures.dart';
+import 'package:owe_me/src/domain/failures/debtor_failures.dart';
 import 'package:owe_me/src/domain/validation/rules/nickname_rules.dart';
 import 'package:owe_me/src/domain/value_objects/money.dart';
 
@@ -16,14 +16,14 @@ class Debtor extends Equatable {
     this.totalDebt = const Money(cents: 0),
   });
 
-  static Either<NicknameValidationFailure, Debtor> create({
+  static Either<DebtorValidationFailure, Debtor> create({
     int? id,
     required String nickname,
     Money totalDebt = const Money(cents: 0),
   }) {
     final failure = NicknameRules.validate(nickname);
     if (failure != null) {
-      return Left(failure);
+      return Left(DebtorValidationFailure(failure));
     }
     return Right(
       Debtor._(
@@ -34,19 +34,23 @@ class Debtor extends Equatable {
     );
   }
 
-  Debtor withMonetaryRecordAdded(MonetaryRecord record) {
+  Either<DebtorValidationFailure, Debtor> withMonetaryRecordAdded(
+    MonetaryRecord record,
+  ) {
     return copyWith(
       totalDebt: record.applyAmountToTotalDebt(totalDebt),
     );
   }
 
-  Debtor withMonetaryRecordRemoved(MonetaryRecord removedRecord) {
+  Either<DebtorValidationFailure, Debtor> withMonetaryRecordRemoved(
+    MonetaryRecord removedRecord,
+  ) {
     return copyWith(
       totalDebt: removedRecord.revertAmountFromTotalDebt(totalDebt),
     );
   }
 
-  Debtor withMonetaryRecordEdited({
+  Either<DebtorValidationFailure, Debtor> withMonetaryRecordEdited({
     required MonetaryRecord newRecord,
     required MonetaryRecord oldRecord,
   }) {
@@ -56,16 +60,17 @@ class Debtor extends Equatable {
     );
   }
 
-  // nickname is intentionally not copyable: it is validated, so changing it must
-  // go through [create]. copyWith only adjusts validity-preserving fields.
-  Debtor copyWith({
+  // copyWith re-validates through [create] so no mutation can produce a broken
+  // entity (the always-valid invariant). Returns Either accordingly.
+  Either<DebtorValidationFailure, Debtor> copyWith({
     int? id,
     bool removeId = false,
+    String? nickname,
     Money? totalDebt,
   }) {
-    return Debtor._(
+    return create(
       id: removeId ? null : (id ?? this.id),
-      nickname: nickname,
+      nickname: nickname ?? this.nickname,
       totalDebt: totalDebt ?? this.totalDebt,
     );
   }

--- a/lib/src/domain/entities/debtor.dart
+++ b/lib/src/domain/entities/debtor.dart
@@ -1,5 +1,8 @@
+import 'package:dartz/dartz.dart';
 import 'package:equatable/equatable.dart';
 import 'package:owe_me/src/domain/entities/monetary_record.dart';
+import 'package:owe_me/src/domain/validation/failures/nickname_validation_failures.dart';
+import 'package:owe_me/src/domain/validation/rules/nickname_rules.dart';
 import 'package:owe_me/src/domain/value_objects/money.dart';
 
 class Debtor extends Equatable {
@@ -7,11 +10,29 @@ class Debtor extends Equatable {
   final String nickname;
   final Money totalDebt;
 
-  const Debtor({
+  const Debtor._({
     this.id,
     required this.nickname,
     this.totalDebt = const Money(cents: 0),
   });
+
+  static Either<NicknameValidationFailure, Debtor> create({
+    int? id,
+    required String nickname,
+    Money totalDebt = const Money(cents: 0),
+  }) {
+    final failure = NicknameRules.validate(nickname);
+    if (failure != null) {
+      return Left(failure);
+    }
+    return Right(
+      Debtor._(
+        id: id,
+        nickname: nickname,
+        totalDebt: totalDebt,
+      ),
+    );
+  }
 
   Debtor withMonetaryRecordAdded(MonetaryRecord record) {
     return copyWith(
@@ -35,15 +56,16 @@ class Debtor extends Equatable {
     );
   }
 
+  // nickname is intentionally not copyable: it is validated, so changing it must
+  // go through [create]. copyWith only adjusts validity-preserving fields.
   Debtor copyWith({
     int? id,
     bool removeId = false,
-    String? nickname,
     Money? totalDebt,
   }) {
-    return Debtor(
+    return Debtor._(
       id: removeId ? null : (id ?? this.id),
-      nickname: nickname ?? this.nickname,
+      nickname: nickname,
       totalDebt: totalDebt ?? this.totalDebt,
     );
   }

--- a/lib/src/domain/entities/favorite_description.dart
+++ b/lib/src/domain/entities/favorite_description.dart
@@ -2,6 +2,7 @@ import 'package:dartz/dartz.dart';
 import 'package:equatable/equatable.dart';
 import 'package:owe_me/src/domain/enums/owe_type.dart';
 import 'package:owe_me/src/domain/failures/favorite_description_failures.dart';
+import 'package:owe_me/src/domain/validation/rules/favorite_description_rules.dart';
 
 class FavoriteDescription extends Equatable {
   final int? id; // Null ID for new records
@@ -19,10 +20,9 @@ class FavoriteDescription extends Equatable {
     required String description,
     required OweType favoriteType,
   }) {
-    if (description.trim().isEmpty) {
-      return Left(
-        FavoriteDescriptionEmptyFailure(),
-      );
+    final failure = FavoriteDescriptionRules.validate(description);
+    if (failure != null) {
+      return Left(failure);
     }
     return Right(
       FavoriteDescription._(

--- a/lib/src/domain/entities/monetary_record.dart
+++ b/lib/src/domain/entities/monetary_record.dart
@@ -1,4 +1,7 @@
+import 'package:dartz/dartz.dart';
 import 'package:equatable/equatable.dart';
+import 'package:owe_me/src/domain/validation/failures/description_validation_failures.dart';
+import 'package:owe_me/src/domain/validation/rules/description_rules.dart';
 import 'package:owe_me/src/domain/value_objects/money.dart';
 import 'package:owe_me/src/domain/enums/owe_type.dart';
 import 'package:owe_me/src/domain/enums/payment_method.dart';

--- a/lib/src/domain/entities/monetary_record.dart
+++ b/lib/src/domain/entities/monetary_record.dart
@@ -1,6 +1,6 @@
 import 'package:dartz/dartz.dart';
 import 'package:equatable/equatable.dart';
-import 'package:owe_me/src/domain/validation/failures/description_validation_failures.dart';
+import 'package:owe_me/src/domain/failures/owe_record_failures.dart';
 import 'package:owe_me/src/domain/validation/rules/description_rules.dart';
 import 'package:owe_me/src/domain/value_objects/money.dart';
 import 'package:owe_me/src/domain/enums/owe_type.dart';

--- a/lib/src/domain/entities/owe_record.dart
+++ b/lib/src/domain/entities/owe_record.dart
@@ -4,13 +4,37 @@ class OweRecord extends MonetaryRecord {
   final String? description;
   final OweType oweType;
 
-  const OweRecord({
+  const OweRecord._({
     required super.id,
     required super.amount,
     required super.date,
     required this.description,
     required this.oweType,
   });
+
+  static Either<DescriptionValidationFailure, OweRecord> create({
+    required int? id,
+    required RecordAmount amount,
+    required DateTime date,
+    required String? description,
+    required OweType oweType,
+  }) {
+    if (description != null) {
+      final failure = DescriptionRules.validate(description);
+      if (failure != null) {
+        return Left(failure);
+      }
+    }
+    return Right(
+      OweRecord._(
+        id: id,
+        amount: amount,
+        date: date,
+        description: description,
+        oweType: oweType,
+      ),
+    );
+  }
 
   @override
   Money applyAmountToTotalDebt(Money totalDebt) {
@@ -28,19 +52,19 @@ class OweRecord extends MonetaryRecord {
     };
   }
 
+  // description is intentionally not copyable: it is validated, so changing it
+  // must go through [create]. copyWith only adjusts validity-preserving fields.
   OweRecord copyWith({
     int? id,
     bool removeId = false,
     RecordAmount? amount,
-    String? description,
-    bool removeDescription = false,
     DateTime? date,
     OweType? oweType,
   }) {
-    return OweRecord(
+    return OweRecord._(
       id: removeId ? null : (id ?? this.id),
       amount: amount ?? this.amount,
-      description: removeDescription ? null : (description ?? this.description),
+      description: description,
       date: date ?? this.date,
       oweType: oweType ?? this.oweType,
     );

--- a/lib/src/domain/entities/owe_record.dart
+++ b/lib/src/domain/entities/owe_record.dart
@@ -12,7 +12,7 @@ class OweRecord extends MonetaryRecord {
     required this.oweType,
   });
 
-  static Either<DescriptionValidationFailure, OweRecord> create({
+  static Either<OweRecordValidationFailure, OweRecord> create({
     required int? id,
     required RecordAmount amount,
     required DateTime date,
@@ -22,7 +22,7 @@ class OweRecord extends MonetaryRecord {
     if (description != null) {
       final failure = DescriptionRules.validate(description);
       if (failure != null) {
-        return Left(failure);
+        return Left(OweRecordValidationFailure(failure));
       }
     }
     return Right(
@@ -52,19 +52,21 @@ class OweRecord extends MonetaryRecord {
     };
   }
 
-  // description is intentionally not copyable: it is validated, so changing it
-  // must go through [create]. copyWith only adjusts validity-preserving fields.
-  OweRecord copyWith({
+  // copyWith re-validates through [create] so no mutation can produce a broken
+  // entity (the always-valid invariant). Returns Either accordingly.
+  Either<OweRecordValidationFailure, OweRecord> copyWith({
     int? id,
     bool removeId = false,
     RecordAmount? amount,
+    String? description,
+    bool removeDescription = false,
     DateTime? date,
     OweType? oweType,
   }) {
-    return OweRecord._(
+    return create(
       id: removeId ? null : (id ?? this.id),
       amount: amount ?? this.amount,
-      description: description,
+      description: removeDescription ? null : (description ?? this.description),
       date: date ?? this.date,
       oweType: oweType ?? this.oweType,
     );

--- a/lib/src/domain/failures/debtor_failures.dart
+++ b/lib/src/domain/failures/debtor_failures.dart
@@ -1,0 +1,7 @@
+import 'package:owe_me/src/core/error/failures/failures.dart';
+
+/// Signals that a [Debtor] would be in an invalid state. Carries the underlying
+/// rule failure as [cause] (diagnostic, like an exception's cause chain).
+class DebtorValidationFailure extends Failure {
+  DebtorValidationFailure(Failure cause) : super(cause.message, cause: cause);
+}

--- a/lib/src/domain/failures/favorite_description_failures.dart
+++ b/lib/src/domain/failures/favorite_description_failures.dart
@@ -13,3 +13,8 @@ class FavoriteDescriptionEmptyFailure extends FavoriteDescriptionFailure {
   const FavoriteDescriptionEmptyFailure()
       : super('Favorite description cannot be empty.');
 }
+
+class FavoriteDescriptionTooLongFailure extends FavoriteDescriptionFailure {
+  const FavoriteDescriptionTooLongFailure()
+      : super('Favorite description exceeds the maximum allowed limit.');
+}

--- a/lib/src/domain/failures/owe_record_failures.dart
+++ b/lib/src/domain/failures/owe_record_failures.dart
@@ -1,0 +1,8 @@
+import 'package:owe_me/src/core/error/failures/failures.dart';
+
+/// Signals that an [OweRecord] would be in an invalid state. Carries the
+/// underlying rule failure as [cause] (diagnostic, like an exception's cause
+/// chain).
+class OweRecordValidationFailure extends Failure {
+  OweRecordValidationFailure(Failure cause) : super(cause.message, cause: cause);
+}

--- a/lib/src/domain/use_cases/monetary_record/add_monetary_record_and_update_debtor.dart
+++ b/lib/src/domain/use_cases/monetary_record/add_monetary_record_and_update_debtor.dart
@@ -15,16 +15,18 @@ class AddMonetaryRecordAndUpdateDebtor {
     required MonetaryRecord monetaryRecord,
     required Debtor recordDebtor,
   }) async {
-    final debtorWithUpdatedDebt = recordDebtor.withMonetaryRecordAdded(monetaryRecord);
-
-    final result = await _repository.addMonetaryRecordAndUpdateDebtor(
-      monetaryRecord,
-      debtorWithUpdatedDebt,
-    );
-
-    return result.fold(
-      (failure) => Left(failure),
-      (_) => Right(debtorWithUpdatedDebt),
+    return recordDebtor.withMonetaryRecordAdded(monetaryRecord).fold(
+      (failure) async => Left(failure),
+      (debtorWithUpdatedDebt) async {
+        final result = await _repository.addMonetaryRecordAndUpdateDebtor(
+          monetaryRecord,
+          debtorWithUpdatedDebt,
+        );
+        return result.fold(
+          (failure) => Left(failure),
+          (_) => Right(debtorWithUpdatedDebt),
+        );
+      },
     );
   }
 }

--- a/lib/src/domain/use_cases/monetary_record/edit_monetary_record_and_update_debtor.dart
+++ b/lib/src/domain/use_cases/monetary_record/edit_monetary_record_and_update_debtor.dart
@@ -16,19 +16,23 @@ class EditMonetaryRecordAndUpdateDebtor {
     required MonetaryRecord oldMonetaryRecord,
     required Debtor recordDebtor,
   }) async {
-    final debtorWithUpdatedDebt = recordDebtor.withMonetaryRecordEdited(
+    return recordDebtor
+        .withMonetaryRecordEdited(
       newRecord: newMonetaryRecord,
       oldRecord: oldMonetaryRecord,
-    );
-
-    final result = await _repository.editMonetaryRecordAndUpdateDebtor(
-      newMonetaryRecord,
-      debtorWithUpdatedDebt,
-    );
-
-    return result.fold(
-      (failure) => Left(failure),
-      (_) => Right(debtorWithUpdatedDebt),
+    )
+        .fold(
+      (failure) async => Left(failure),
+      (debtorWithUpdatedDebt) async {
+        final result = await _repository.editMonetaryRecordAndUpdateDebtor(
+          newMonetaryRecord,
+          debtorWithUpdatedDebt,
+        );
+        return result.fold(
+          (failure) => Left(failure),
+          (_) => Right(debtorWithUpdatedDebt),
+        );
+      },
     );
   }
 }

--- a/lib/src/domain/use_cases/monetary_record/remove_monetary_record_and_update_debtor.dart
+++ b/lib/src/domain/use_cases/monetary_record/remove_monetary_record_and_update_debtor.dart
@@ -15,16 +15,18 @@ class RemoveMonetaryRecordAndUpdateDebtor {
     required MonetaryRecord monetaryRecord,
     required Debtor recordDebtor,
   }) async {
-    final debtorWithUpdatedDebt = recordDebtor.withMonetaryRecordRemoved(monetaryRecord);
-
-    final result = await _repository.removeMonetaryRecordAndUpdateDebtor(
-      monetaryRecord,
-      debtorWithUpdatedDebt,
-    );
-
-    return result.fold(
-      (failure) => Left(failure),
-      (_) => Right(debtorWithUpdatedDebt),
+    return recordDebtor.withMonetaryRecordRemoved(monetaryRecord).fold(
+      (failure) async => Left(failure),
+      (debtorWithUpdatedDebt) async {
+        final result = await _repository.removeMonetaryRecordAndUpdateDebtor(
+          monetaryRecord,
+          debtorWithUpdatedDebt,
+        );
+        return result.fold(
+          (failure) => Left(failure),
+          (_) => Right(debtorWithUpdatedDebt),
+        );
+      },
     );
   }
 }

--- a/lib/src/domain/validation/failures/description_validation_failures.dart
+++ b/lib/src/domain/validation/failures/description_validation_failures.dart
@@ -1,0 +1,10 @@
+import 'package:owe_me/src/domain/validation/failures/validation_failure.dart';
+
+sealed class DescriptionValidationFailure extends ValidationFailure {
+  const DescriptionValidationFailure(super.message);
+}
+
+class DescriptionExceedsLimitFailure extends DescriptionValidationFailure {
+  const DescriptionExceedsLimitFailure()
+      : super('Description exceeds the maximum allowed limit.');
+}

--- a/lib/src/domain/validation/failures/nickname_validation_failures.dart
+++ b/lib/src/domain/validation/failures/nickname_validation_failures.dart
@@ -1,0 +1,14 @@
+import 'package:owe_me/src/domain/validation/failures/validation_failure.dart';
+
+sealed class NicknameValidationFailure extends ValidationFailure {
+  const NicknameValidationFailure(super.message);
+}
+
+class NicknameEmptyFailure extends NicknameValidationFailure {
+  const NicknameEmptyFailure() : super('Nickname cannot be empty.');
+}
+
+class NicknameExceedsLimitFailure extends NicknameValidationFailure {
+  const NicknameExceedsLimitFailure()
+      : super('Nickname exceeds the maximum allowed limit.');
+}

--- a/lib/src/domain/validation/rules/description_rules.dart
+++ b/lib/src/domain/validation/rules/description_rules.dart
@@ -1,0 +1,15 @@
+import 'package:owe_me/src/domain/validation/failures/description_validation_failures.dart';
+
+class DescriptionRules {
+  const DescriptionRules._();
+
+  static const maxLength = 100;
+
+  static DescriptionValidationFailure? validate(String description) {
+    if (description.length > DescriptionRules.maxLength) {
+      return const DescriptionExceedsLimitFailure();
+    }
+
+    return null;
+  }
+}

--- a/lib/src/domain/validation/rules/favorite_description_rules.dart
+++ b/lib/src/domain/validation/rules/favorite_description_rules.dart
@@ -1,0 +1,18 @@
+import 'package:owe_me/src/domain/failures/favorite_description_failures.dart';
+import 'package:owe_me/src/domain/validation/rules/description_rules.dart';
+
+class FavoriteDescriptionRules {
+  const FavoriteDescriptionRules._();
+
+  static FavoriteDescriptionFailure? validate(String description) {
+    if (description.trim().isEmpty) {
+      return const FavoriteDescriptionEmptyFailure();
+    }
+
+    if (description.length > DescriptionRules.maxLength) {
+      return const FavoriteDescriptionTooLongFailure();
+    }
+
+    return null;
+  }
+}

--- a/lib/src/domain/validation/rules/nickname_rules.dart
+++ b/lib/src/domain/validation/rules/nickname_rules.dart
@@ -1,0 +1,19 @@
+import 'package:owe_me/src/domain/validation/failures/nickname_validation_failures.dart';
+
+class NicknameRules {
+  const NicknameRules._();
+
+  static const maxLength = 50;
+
+  static NicknameValidationFailure? validate(String nickname) {
+    if (nickname.trim().isEmpty) {
+      return const NicknameEmptyFailure();
+    }
+
+    if (nickname.length > NicknameRules.maxLength) {
+      return const NicknameExceedsLimitFailure();
+    }
+
+    return null;
+  }
+}

--- a/lib/src/presentation/blocs/debtor/debtor_bloc.dart
+++ b/lib/src/presentation/blocs/debtor/debtor_bloc.dart
@@ -2,12 +2,14 @@ import 'dart:async';
 
 import 'package:equatable/equatable.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:owe_me/src/core/presentation/extensions/dartz_extensions.dart';
 import 'package:owe_me/src/domain/entities/debtor.dart';
 import 'package:owe_me/src/domain/entities/monetary_record.dart';
 import 'package:owe_me/src/domain/use_cases/debtor/edit_debtor.dart';
 import 'package:owe_me/src/domain/use_cases/debtor/remove_debtor.dart';
 import 'package:owe_me/src/domain/use_cases/monetary_record/load_debtor_monetary_record_history.dart';
 import 'package:owe_me/src/domain/use_cases/monetary_record/remove_monetary_record_and_update_debtor.dart';
+import 'package:owe_me/src/presentation/validation_mappers/nickname_validation_mapper.dart';
 
 part 'debtor_event.dart';
 part 'debtor_state.dart';
@@ -78,7 +80,16 @@ class DebtorBloc extends Bloc<DebtorEvent, DebtorState> {
     Emitter<DebtorState> emit,
   ) async {
     emit(DebtorEditInProgress());
-    final debtor = _debtor.copyWith(nickname: event.nickname);
+    final editedDebtor = Debtor.create(
+      id: _debtor.id,
+      nickname: event.nickname,
+      totalDebt: _debtor.totalDebt,
+    );
+    if (editedDebtor.isLeft()) {
+      emit(DebtorEditError(message: editedDebtor.asLeft().uiMessage));
+      return;
+    }
+    final debtor = editedDebtor.asRight();
     final response = await _editDebtorUseCase(
       debtor: debtor,
     );

--- a/lib/src/presentation/blocs/debtor/debtor_bloc.dart
+++ b/lib/src/presentation/blocs/debtor/debtor_bloc.dart
@@ -9,7 +9,6 @@ import 'package:owe_me/src/domain/use_cases/debtor/edit_debtor.dart';
 import 'package:owe_me/src/domain/use_cases/debtor/remove_debtor.dart';
 import 'package:owe_me/src/domain/use_cases/monetary_record/load_debtor_monetary_record_history.dart';
 import 'package:owe_me/src/domain/use_cases/monetary_record/remove_monetary_record_and_update_debtor.dart';
-import 'package:owe_me/src/presentation/validation_mappers/nickname_validation_mapper.dart';
 
 part 'debtor_event.dart';
 part 'debtor_state.dart';
@@ -86,7 +85,7 @@ class DebtorBloc extends Bloc<DebtorEvent, DebtorState> {
       totalDebt: _debtor.totalDebt,
     );
     if (editedDebtor.isLeft()) {
-      emit(DebtorEditError(message: editedDebtor.asLeft().uiMessage));
+      emit(DebtorEditError(message: editedDebtor.asLeft().message));
       return;
     }
     final debtor = editedDebtor.asRight();

--- a/lib/src/presentation/blocs/home_debtors/home_debtors_bloc.dart
+++ b/lib/src/presentation/blocs/home_debtors/home_debtors_bloc.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:equatable/equatable.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:owe_me/src/core/presentation/extensions/dartz_extensions.dart';
 import 'package:owe_me/src/domain/entities/debtor.dart';
 import 'package:owe_me/src/domain/use_cases/debtor/add_debtor.dart';
 import 'package:owe_me/src/domain/use_cases/debtor/load_debtors.dart';
@@ -44,8 +45,13 @@ class HomeDebtorsBloc extends Bloc<HomeDebtorsEvent, HomeDebtorsState> {
     Emitter<HomeDebtorsState> emit,
   ) async {
     emit(HomeDebtorsLoading());
+    final newDebtor = Debtor.create(nickname: event.debtorNickname);
+    if (newDebtor.isLeft()) {
+      emit(HomeDebtorsError());
+      return;
+    }
     final response = await _addDebtorUseCase(
-      debtor: Debtor(nickname: event.debtorNickname),
+      debtor: newDebtor.asRight(),
     );
     response.fold(
       (exception) => emit(HomeDebtorsError()),

--- a/lib/src/presentation/blocs/set_owe_record/info_review/set_owe_record_info_review_bloc.dart
+++ b/lib/src/presentation/blocs/set_owe_record/info_review/set_owe_record_info_review_bloc.dart
@@ -53,14 +53,23 @@ class SetOweRecordInfoReviewBloc
       }
 
       final oweRecord = value.asRight();
+      var recordToSave = oweRecord;
+      if (_isEdition) {
+        final editedRecord = oweRecord.copyWith(id: _oweRecordToEdit!.id);
+        if (editedRecord.isLeft()) {
+          emit(SetOweRecordInfoReviewError());
+          return;
+        }
+        recordToSave = editedRecord.asRight();
+      }
       final result = _isEdition
           ? await _editMonetaryRecordAndUpdateDebtorUseCase(
-              newMonetaryRecord: oweRecord.copyWith(id: _oweRecordToEdit!.id),
+              newMonetaryRecord: recordToSave,
               oldMonetaryRecord: _oweRecordToEdit!,
               recordDebtor: _recordDebtor,
             )
           : await _addMonetaryRecordAndUpdateDebtorUseCase(
-              monetaryRecord: oweRecord,
+              monetaryRecord: recordToSave,
               recordDebtor: _recordDebtor,
             );
 

--- a/lib/src/presentation/models/drafts/owe_record_draft.dart
+++ b/lib/src/presentation/models/drafts/owe_record_draft.dart
@@ -5,7 +5,6 @@ import 'package:owe_me/src/domain/entities/monetary_record.dart';
 import 'package:owe_me/src/domain/value_objects/money.dart';
 import 'package:owe_me/src/domain/enums/owe_type.dart';
 import 'package:owe_me/src/domain/value_objects/record_amount.dart';
-import 'package:owe_me/src/presentation/validation_mappers/description_validation_mapper.dart';
 
 class OweRecordDraft {
   final Money? amount;
@@ -53,7 +52,7 @@ class OweRecordDraft {
       date: date!,
       oweType: oweType,
     ).fold(
-      (failure) => Left(InvalidDraftFailure(failure.uiMessage)),
+      (failure) => Left(InvalidDraftFailure(failure.message)),
       (record) => Right(record),
     );
   }

--- a/lib/src/presentation/models/drafts/owe_record_draft.dart
+++ b/lib/src/presentation/models/drafts/owe_record_draft.dart
@@ -5,6 +5,7 @@ import 'package:owe_me/src/domain/entities/monetary_record.dart';
 import 'package:owe_me/src/domain/value_objects/money.dart';
 import 'package:owe_me/src/domain/enums/owe_type.dart';
 import 'package:owe_me/src/domain/value_objects/record_amount.dart';
+import 'package:owe_me/src/presentation/validation_mappers/description_validation_mapper.dart';
 
 class OweRecordDraft {
   final Money? amount;
@@ -45,14 +46,15 @@ class OweRecordDraft {
       return Left(InvalidDraftFailure('Data é obrigatória'));
     }
 
-    return Right(
-      OweRecord(
-        id: null, // ID will be assigned when saved in database
-        amount: amount.asRight(),
-        description: description,
-        date: date!,
-        oweType: oweType,
-      ),
+    return OweRecord.create(
+      id: null, // ID will be assigned when saved in database
+      amount: amount.asRight(),
+      description: description,
+      date: date!,
+      oweType: oweType,
+    ).fold(
+      (failure) => Left(InvalidDraftFailure(failure.uiMessage)),
+      (record) => Right(record),
     );
   }
 }

--- a/lib/src/presentation/validation_mappers/description_validation_mapper.dart
+++ b/lib/src/presentation/validation_mappers/description_validation_mapper.dart
@@ -1,0 +1,12 @@
+import 'package:owe_me/src/domain/validation/failures/description_validation_failures.dart';
+import 'package:owe_me/src/domain/validation/rules/description_rules.dart';
+
+extension DescriptionFailureDisplay on DescriptionValidationFailure {
+  String get uiMessage {
+    switch (this) {
+      case DescriptionExceedsLimitFailure():
+        return 'A descrição não pode ter mais de '
+            '${DescriptionRules.maxLength} caracteres.';
+    }
+  }
+}

--- a/lib/src/presentation/validation_mappers/favorite_description_validation_mapper.dart
+++ b/lib/src/presentation/validation_mappers/favorite_description_validation_mapper.dart
@@ -1,4 +1,5 @@
 import 'package:owe_me/src/domain/failures/favorite_description_failures.dart';
+import 'package:owe_me/src/domain/validation/rules/description_rules.dart';
 
 extension FavoriteDescriptionFailureDisplay on FavoriteDescriptionFailure {
   String get uiMessage {
@@ -7,6 +8,9 @@ extension FavoriteDescriptionFailureDisplay on FavoriteDescriptionFailure {
         return 'Esta descrição já está entre os favoritos.';
       case FavoriteDescriptionEmptyFailure():
         return 'A descrição não pode estar vazia para ser adicionada aos favoritos.';
+      case FavoriteDescriptionTooLongFailure():
+        return 'A descrição não pode ter mais de '
+            '${DescriptionRules.maxLength} caracteres.';
     }
   }
 }

--- a/lib/src/presentation/validation_mappers/nickname_validation_mapper.dart
+++ b/lib/src/presentation/validation_mappers/nickname_validation_mapper.dart
@@ -1,0 +1,14 @@
+import 'package:owe_me/src/domain/validation/failures/nickname_validation_failures.dart';
+import 'package:owe_me/src/domain/validation/rules/nickname_rules.dart';
+
+extension NicknameFailureDisplay on NicknameValidationFailure {
+  String get uiMessage {
+    switch (this) {
+      case NicknameEmptyFailure():
+        return 'Apelido é obrigatório.';
+      case NicknameExceedsLimitFailure():
+        return 'O apelido não pode ter mais de '
+            '${NicknameRules.maxLength} caracteres.';
+    }
+  }
+}

--- a/lib/src/presentation/widgets/home_page/debtor_list_item.dart
+++ b/lib/src/presentation/widgets/home_page/debtor_list_item.dart
@@ -1,13 +1,12 @@
 import 'package:flutter/material.dart';
+import 'package:owe_me/src/core/presentation/design_system/owe_me_colors.dart';
+import 'package:owe_me/src/core/presentation/design_system/owe_me_text_styles.dart';
 import 'package:owe_me/src/core/presentation/formatters/money_formatter.dart';
 import 'package:owe_me/src/domain/entities/debtor.dart';
 import 'package:owe_me/src/domain/enums/owe_type.dart';
 import 'package:owe_me/src/presentation/containers/debtor_container.dart';
 import 'package:owe_me/src/presentation/containers/set_owe_record/set_owe_record_amount_step_container.dart';
 import 'package:owe_me/src/presentation/containers/set_payment_record/set_payment_record_form_container.dart';
-import 'package:owe_me/src/core/presentation/design_system/owe_me_colors.dart';
-import 'package:owe_me/src/core/presentation/design_system/owe_me_text_styles.dart';
-import 'package:owe_me/src/presentation/widgets/shared/owe_me_spacer.dart';
 
 class DebtorListItem extends StatelessWidget {
   final Debtor debtor;
@@ -70,25 +69,27 @@ class DebtorListItem extends StatelessWidget {
         onTap: () => _navigateToDebtorPage(context),
         borderRadius: BorderRadius.circular(12),
         child: Container(
-          height: 80,
+          // height: 80,
           padding: const EdgeInsets.all(16),
           child: Row(
             children: [
-              Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(
-                    debtor.nickname,
-                    style: OweMeTextStyles.subtitle,
-                  ),
-                  const SizedBox(width: 8),
-                  Text(
-                    MoneyFormatter.toStringCurrency(debtor.totalDebt),
-                    style: OweMeTextStyles.body,
-                  ),
-                ],
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      debtor.nickname,
+                      style: OweMeTextStyles.subtitle,
+                    ),
+                    const SizedBox(width: 8),
+                    Text(
+                      MoneyFormatter.toStringCurrency(debtor.totalDebt),
+                      style: OweMeTextStyles.body,
+                    ),
+                  ],
+                ),
               ),
-              const OweMeSpacer(minWidth: 8),
+              const SizedBox(width: 8),
               IconButton(
                 onPressed: () => _navigateToSetPaymentRecordFormPage(context),
                 icon: const Icon(
@@ -97,14 +98,16 @@ class DebtorListItem extends StatelessWidget {
                 ),
               ),
               IconButton(
-                onPressed: () => _navigateToSetRecordAmountStepPageAsCredit(context),
+                onPressed: () =>
+                    _navigateToSetRecordAmountStepPageAsCredit(context),
                 icon: const Icon(
                   Icons.money_off_csred,
                   color: OweMeColors.primaryBlue,
                 ),
               ),
               IconButton(
-                onPressed: () => _navigateToSetRecordAmountStepPageAsDebt(context),
+                onPressed: () =>
+                    _navigateToSetRecordAmountStepPageAsDebt(context),
                 icon: const Icon(
                   Icons.attach_money,
                   color: OweMeColors.primaryBlue,

--- a/lib/src/presentation/widgets/set_owe_record/description_step_page/set_owe_record_description_text_form_field.dart
+++ b/lib/src/presentation/widgets/set_owe_record/description_step_page/set_owe_record_description_text_form_field.dart
@@ -3,6 +3,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:owe_me/src/presentation/blocs/set_owe_record/description_step/set_owe_record_description_step_bloc.dart';
 import 'package:owe_me/src/core/presentation/design_system/owe_me_colors.dart';
 import 'package:owe_me/src/core/presentation/design_system/owe_me_text_styles.dart';
+import 'package:owe_me/src/domain/validation/rules/description_rules.dart';
 
 class SetOweRecordDescriptionTextFormField extends StatefulWidget {
   final String initialDescription;
@@ -80,6 +81,8 @@ class _SetOweRecordDescriptionTextFormFieldState
         controller: _controller,
         autofocus: true,
         keyboardType: TextInputType.text,
+        textCapitalization: TextCapitalization.sentences,
+        maxLength: DescriptionRules.maxLength,
       ),
     );
   }

--- a/lib/src/presentation/widgets/shared/debtor_selection_list/debtor_selection_list_item.dart
+++ b/lib/src/presentation/widgets/shared/debtor_selection_list/debtor_selection_list_item.dart
@@ -1,10 +1,9 @@
 import 'package:flutter/material.dart';
-import 'package:owe_me/src/core/presentation/formatters/money_formatter.dart';
-import 'package:owe_me/src/domain/entities/debtor.dart';
 import 'package:owe_me/src/core/presentation/callbacks.dart';
 import 'package:owe_me/src/core/presentation/design_system/owe_me_colors.dart';
 import 'package:owe_me/src/core/presentation/design_system/owe_me_text_styles.dart';
-import 'package:owe_me/src/presentation/widgets/shared/owe_me_spacer.dart';
+import 'package:owe_me/src/core/presentation/formatters/money_formatter.dart';
+import 'package:owe_me/src/domain/entities/debtor.dart';
 
 class DebtorSelectionListItem extends StatelessWidget {
   final Debtor debtor;
@@ -26,21 +25,25 @@ class DebtorSelectionListItem extends StatelessWidget {
         onTap: () => onDebtorSelected(debtor),
         borderRadius: BorderRadius.circular(12),
         child: Container(
-          height: 76,
           padding: const EdgeInsets.all(16),
           child: Row(
             children: [
-              Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(debtor.nickname, style: OweMeTextStyles.subtitle),
-                  Text(
-                    MoneyFormatter.toStringCurrency(debtor.totalDebt),
-                    style: OweMeTextStyles.body,
-                  ),
-                ],
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      debtor.nickname,
+                      style: OweMeTextStyles.subtitle,
+                    ),
+                    Text(
+                      MoneyFormatter.toStringCurrency(debtor.totalDebt),
+                      style: OweMeTextStyles.body,
+                    ),
+                  ],
+                ),
               ),
-              const OweMeSpacer(minWidth: 8),
+              const SizedBox(width: 8),
               const Icon(Icons.chevron_right, color: OweMeColors.textGray),
             ],
           ),

--- a/lib/src/presentation/widgets/shared/set_debtor_dialog.dart
+++ b/lib/src/presentation/widgets/shared/set_debtor_dialog.dart
@@ -3,6 +3,8 @@ import 'package:owe_me/src/core/presentation/callbacks.dart';
 import 'package:owe_me/src/core/presentation/design_system/owe_me_colors.dart';
 import 'package:owe_me/src/core/presentation/design_system/owe_me_shadows.dart';
 import 'package:owe_me/src/core/presentation/design_system/owe_me_text_styles.dart';
+import 'package:owe_me/src/domain/validation/rules/nickname_rules.dart';
+import 'package:owe_me/src/presentation/validation_mappers/nickname_validation_mapper.dart';
 
 class SetDebtorDialog extends StatefulWidget {
   final String? initialNickname;
@@ -58,9 +60,10 @@ class _SetDebtorDialogState extends State<SetDebtorDialog> {
 
   void _validateAndSubmit() {
     final nickname = _controller.text.trim();
-    if (nickname.isEmpty) {
+    final failure = NicknameRules.validate(nickname);
+    if (failure != null) {
       setState(() {
-        _errorText = 'Apelido é obrigatório';
+        _errorText = failure.uiMessage;
       });
     } else {
       widget.onSetDebtorPressed?.call(nickname);
@@ -118,6 +121,8 @@ class _SetDebtorDialogState extends State<SetDebtorDialog> {
                     ),
                   ),
                   style: OweMeTextStyles.body,
+                  textCapitalization: TextCapitalization.words,
+                  maxLength: NicknameRules.maxLength,
                 ),
                 if (_errorText != null)
                   Padding(

--- a/test/src/domain/entities/debtor_test.dart
+++ b/test/src/domain/entities/debtor_test.dart
@@ -1,35 +1,60 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:owe_me/src/core/presentation/extensions/dartz_extensions.dart';
 import 'package:owe_me/src/domain/entities/debtor.dart';
+import 'package:owe_me/src/domain/failures/debtor_failures.dart';
 import 'package:owe_me/src/domain/validation/failures/nickname_validation_failures.dart';
 import 'package:owe_me/src/domain/validation/rules/nickname_rules.dart';
 import 'package:owe_me/src/domain/value_objects/money.dart';
 
 void main() {
   group('create validation:', () {
-    test('When nickname is empty, it returns NicknameEmptyFailure', () {
+    test('When nickname is empty, it fails with NicknameEmptyFailure as cause',
+        () {
       final result = Debtor.create(nickname: '');
 
-      expect(result.asLeft(), isA<NicknameEmptyFailure>());
+      expect(result.asLeft(), isA<DebtorValidationFailure>());
+      expect(result.asLeft().cause, isA<NicknameEmptyFailure>());
     });
 
-    test('When nickname is whitespace-only, it returns NicknameEmptyFailure', () {
+    test(
+        'When nickname is whitespace-only, it fails with NicknameEmptyFailure as cause',
+        () {
       final result = Debtor.create(nickname: '   ');
 
-      expect(result.asLeft(), isA<NicknameEmptyFailure>());
+      expect(result.asLeft(), isA<DebtorValidationFailure>());
+      expect(result.asLeft().cause, isA<NicknameEmptyFailure>());
     });
 
-    test('When nickname exceeds the limit, it returns NicknameExceedsLimitFailure',
+    test(
+        'When nickname exceeds the limit, it fails with NicknameExceedsLimitFailure as cause',
         () {
       final result = Debtor.create(nickname: 'a' * (NicknameRules.maxLength + 1));
 
-      expect(result.asLeft(), isA<NicknameExceedsLimitFailure>());
+      expect(result.asLeft(), isA<DebtorValidationFailure>());
+      expect(result.asLeft().cause, isA<NicknameExceedsLimitFailure>());
     });
 
     test('When nickname is valid, it returns a Debtor', () {
       final result = Debtor.create(nickname: 'João');
 
       expect(result.asRight(), isA<Debtor>());
+    });
+  });
+
+  group('copyWith validation:', () {
+    final debtor = Debtor.create(nickname: 'João').asRight();
+
+    test('When the new nickname is invalid, copyWith returns a Left', () {
+      final result = debtor.copyWith(nickname: '');
+
+      expect(result.asLeft(), isA<DebtorValidationFailure>());
+      expect(result.asLeft().cause, isA<NicknameEmptyFailure>());
+    });
+
+    test('When changing only totalDebt, copyWith returns a valid Debtor', () {
+      final result = debtor.copyWith(totalDebt: const Money(cents: 500));
+
+      expect(result.asRight().totalDebt, const Money(cents: 500));
     });
   });
 

--- a/test/src/domain/entities/debtor_test.dart
+++ b/test/src/domain/entities/debtor_test.dart
@@ -1,53 +1,87 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:owe_me/src/core/presentation/extensions/dartz_extensions.dart';
 import 'package:owe_me/src/domain/entities/debtor.dart';
+import 'package:owe_me/src/domain/validation/failures/nickname_validation_failures.dart';
+import 'package:owe_me/src/domain/validation/rules/nickname_rules.dart';
 import 'package:owe_me/src/domain/value_objects/money.dart';
 
 void main() {
+  group('create validation:', () {
+    test('When nickname is empty, it returns NicknameEmptyFailure', () {
+      final result = Debtor.create(nickname: '');
+
+      expect(result.asLeft(), isA<NicknameEmptyFailure>());
+    });
+
+    test('When nickname is whitespace-only, it returns NicknameEmptyFailure', () {
+      final result = Debtor.create(nickname: '   ');
+
+      expect(result.asLeft(), isA<NicknameEmptyFailure>());
+    });
+
+    test('When nickname exceeds the limit, it returns NicknameExceedsLimitFailure',
+        () {
+      final result = Debtor.create(nickname: 'a' * (NicknameRules.maxLength + 1));
+
+      expect(result.asLeft(), isA<NicknameExceedsLimitFailure>());
+    });
+
+    test('When nickname is valid, it returns a Debtor', () {
+      final result = Debtor.create(nickname: 'João');
+
+      expect(result.asRight(), isA<Debtor>());
+    });
+  });
+
   group('Equatable props:', () {
     const debtorId = 1;
     const nickname = 'Nickname';
     const totalDebt = Money(cents: 10000);
 
-    const first = Debtor(
+    final first = Debtor.create(
       id: debtorId,
       nickname: nickname,
       totalDebt: totalDebt,
-    );
+    ).asRight();
 
     test('When two entities have the same props, they should be equal', () {
-      const second = Debtor(
+      final second = Debtor.create(
         id: debtorId,
         nickname: nickname,
         totalDebt: totalDebt,
-      );
+      ).asRight();
 
       assert(first == second);
     });
 
     test('When two entities have different [id], they should not be equal', () {
-      const second = Debtor(
+      final second = Debtor.create(
         id: 2,
         nickname: nickname,
         totalDebt: totalDebt,
-      );
+      ).asRight();
 
       assert(first != second);
     });
-    test('When two entities have different [nickname], they should not be equal', () {
-      const second = Debtor(
+
+    test('When two entities have different [nickname], they should not be equal',
+        () {
+      final second = Debtor.create(
         id: debtorId,
         nickname: 'Another Nickname',
         totalDebt: totalDebt,
-      );
+      ).asRight();
 
       assert(first != second);
     });
-    test('When two entities have different [totalDebt], they should not be equal', () {
-      const second = Debtor(
+
+    test('When two entities have different [totalDebt], they should not be equal',
+        () {
+      final second = Debtor.create(
         id: debtorId,
         nickname: nickname,
-        totalDebt: Money(cents: 20000),
-      );
+        totalDebt: const Money(cents: 20000),
+      ).asRight();
 
       assert(first != second);
     });

--- a/test/src/domain/entities/favorite_description_test.dart
+++ b/test/src/domain/entities/favorite_description_test.dart
@@ -2,6 +2,8 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:owe_me/src/core/presentation/extensions/dartz_extensions.dart';
 import 'package:owe_me/src/domain/entities/favorite_description.dart';
 import 'package:owe_me/src/domain/enums/owe_type.dart';
+import 'package:owe_me/src/domain/failures/favorite_description_failures.dart';
+import 'package:owe_me/src/domain/validation/rules/description_rules.dart';
 
 void main() {
   group('Equatable props:', () {
@@ -35,7 +37,9 @@ void main() {
       assert(first != second);
     });
 
-    test('When two entities have different [description], they should not be equal', () {
+    test(
+        'When two entities have different [description], they should not be equal',
+        () {
       final second = FavoriteDescription.create(
         id: id,
         description: 'another description',
@@ -45,7 +49,9 @@ void main() {
       assert(first != second);
     });
 
-    test('When two entities have different [favoriteType], they should not be equal', () {
+    test(
+        'When two entities have different [favoriteType], they should not be equal',
+        () {
       final second = FavoriteDescription.create(
         id: id,
         description: description,
@@ -53,6 +59,50 @@ void main() {
       ).asRight();
 
       assert(first != second);
+    });
+  });
+
+  group('create validation:', () {
+    test(
+        'When description is empty, it returns FavoriteDescriptionEmptyFailure',
+        () {
+      final result = FavoriteDescription.create(
+        description: '',
+        favoriteType: OweType.debt,
+      );
+
+      expect(result.asLeft(), isA<FavoriteDescriptionEmptyFailure>());
+    });
+
+    test(
+        'When description is whitespace-only, it returns FavoriteDescriptionEmptyFailure',
+        () {
+      final result = FavoriteDescription.create(
+        description: '   ',
+        favoriteType: OweType.debt,
+      );
+
+      expect(result.asLeft(), isA<FavoriteDescriptionEmptyFailure>());
+    });
+
+    test(
+        'When description exceeds the limit, it returns FavoriteDescriptionTooLongFailure',
+        () {
+      final result = FavoriteDescription.create(
+        description: 'a' * (DescriptionRules.maxLength + 1),
+        favoriteType: OweType.debt,
+      );
+
+      expect(result.asLeft(), isA<FavoriteDescriptionTooLongFailure>());
+    });
+
+    test('When description is valid, it returns a FavoriteDescription', () {
+      final result = FavoriteDescription.create(
+        description: 'Almoço',
+        favoriteType: OweType.debt,
+      );
+
+      expect(result.asRight(), isA<FavoriteDescription>());
     });
   });
 }

--- a/test/src/domain/entities/owe_record_test.dart
+++ b/test/src/domain/entities/owe_record_test.dart
@@ -1,96 +1,119 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:owe_me/src/core/presentation/extensions/dartz_extensions.dart';
 import 'package:owe_me/src/domain/entities/monetary_record.dart';
-import 'package:owe_me/src/domain/value_objects/money.dart';
 import 'package:owe_me/src/domain/enums/owe_type.dart';
+import 'package:owe_me/src/domain/validation/failures/description_validation_failures.dart';
+import 'package:owe_me/src/domain/validation/rules/description_rules.dart';
+import 'package:owe_me/src/domain/value_objects/money.dart';
 import 'package:owe_me/src/domain/value_objects/record_amount.dart';
 
 void main() {
-  group('OweRecord Equatable props:', () {
-    const id = 1;
-    final amount = RecordAmount.create(Money(cents: 100)).asRight();
-    final date = DateTime(2023);
-    const description = 'Description';
+  final amount = RecordAmount.create(Money(cents: 100)).asRight();
+  final date = DateTime(2023);
 
-    final entity = OweRecord(
+  OweRecord buildOweRecord({
+    int? id = 1,
+    String? description = 'Description',
+    OweType oweType = OweType.debt,
+  }) {
+    return OweRecord.create(
       id: id,
       amount: amount,
       date: date,
       description: description,
-      oweType: OweType.debt,
-    );
+      oweType: oweType,
+    ).asRight();
+  }
+
+  group('create validation:', () {
+    test('When description is null, it returns an OweRecord', () {
+      final result = OweRecord.create(
+        id: 1,
+        amount: amount,
+        date: date,
+        description: null,
+        oweType: OweType.debt,
+      );
+
+      expect(result.asRight(), isA<OweRecord>());
+    });
+
+    test(
+        'When description exceeds the limit, it returns DescriptionExceedsLimitFailure',
+        () {
+      final result = OweRecord.create(
+        id: 1,
+        amount: amount,
+        date: date,
+        description: 'a' * (DescriptionRules.maxLength + 1),
+        oweType: OweType.debt,
+      );
+
+      expect(result.asLeft(), isA<DescriptionExceedsLimitFailure>());
+    });
+
+    test('When description is within the limit, it returns an OweRecord', () {
+      final result = OweRecord.create(
+        id: 1,
+        amount: amount,
+        date: date,
+        description: 'Almoço',
+        oweType: OweType.debt,
+      );
+
+      expect(result.asRight(), isA<OweRecord>());
+    });
+  });
+
+  group('OweRecord Equatable props:', () {
+    final entity = buildOweRecord();
 
     test('When two OweRecords have the same props, they should be equal', () {
-      final second = OweRecord(
-        id: id,
-        amount: amount,
-        date: date,
-        description: description,
-        oweType: OweType.debt,
-      );
-
-      expect(entity, equals(second));
+      expect(entity, equals(buildOweRecord()));
     });
 
-    test('When two OweRecords have different [id], they should not be equal', () {
-      final second = OweRecord(
-        id: 2,
-        amount: amount,
-        date: date,
-        description: description,
-        oweType: OweType.debt,
-      );
-
-      expect(entity, isNot(equals(second)));
+    test('When two OweRecords have different [id], they should not be equal',
+        () {
+      expect(entity, isNot(equals(buildOweRecord(id: 2))));
     });
 
-    test('When two OweRecords have different [amount], they should not be equal', () {
-      final second = OweRecord(
-        id: id,
+    test(
+        'When two OweRecords have different [amount], they should not be equal',
+        () {
+      final second = OweRecord.create(
+        id: 1,
         amount: RecordAmount.create(Money(cents: 200)).asRight(),
         date: date,
-        description: description,
+        description: 'Description',
         oweType: OweType.debt,
-      );
+      ).asRight();
 
       expect(entity, isNot(equals(second)));
     });
 
-    test('When two OweRecords have different [date], they should not be equal', () {
-      final second = OweRecord(
-        id: id,
+    test('When two OweRecords have different [date], they should not be equal',
+        () {
+      final second = OweRecord.create(
+        id: 1,
         amount: amount,
         date: DateTime(2024),
-        description: description,
+        description: 'Description',
         oweType: OweType.debt,
-      );
+      ).asRight();
 
       expect(entity, isNot(equals(second)));
     });
 
-    test('When two OweRecords have different [description], they should not be equal',
+    test(
+        'When two OweRecords have different [description], they should not be equal',
         () {
-      final second = OweRecord(
-        id: id,
-        amount: amount,
-        date: date,
-        description: 'Another Description',
-        oweType: OweType.debt,
-      );
-
-      expect(entity, isNot(equals(second)));
+      expect(entity,
+          isNot(equals(buildOweRecord(description: 'Another Description'))));
     });
 
-    test('When two OweRecords have different [type], they should not be equal', () {
-      final second = OweRecord(
-        id: id,
-        amount: amount,
-        date: date,
-        description: 'Another Description',
-        oweType: OweType.credit,
-      );
-
-      expect(entity, isNot(equals(second)));
+    test('When two OweRecords have different [type], they should not be equal',
+        () {
+      expect(entity, isNot(equals(buildOweRecord(oweType: OweType.credit))));
     });
   });
 }

--- a/test/src/domain/entities/owe_record_test.dart
+++ b/test/src/domain/entities/owe_record_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:owe_me/src/core/presentation/extensions/dartz_extensions.dart';
 import 'package:owe_me/src/domain/entities/monetary_record.dart';
 import 'package:owe_me/src/domain/enums/owe_type.dart';
+import 'package:owe_me/src/domain/failures/owe_record_failures.dart';
 import 'package:owe_me/src/domain/validation/failures/description_validation_failures.dart';
 import 'package:owe_me/src/domain/validation/rules/description_rules.dart';
 import 'package:owe_me/src/domain/value_objects/money.dart';
@@ -39,7 +40,7 @@ void main() {
     });
 
     test(
-        'When description exceeds the limit, it returns DescriptionExceedsLimitFailure',
+        'When description exceeds the limit, it fails with DescriptionExceedsLimitFailure as cause',
         () {
       final result = OweRecord.create(
         id: 1,
@@ -49,7 +50,8 @@ void main() {
         oweType: OweType.debt,
       );
 
-      expect(result.asLeft(), isA<DescriptionExceedsLimitFailure>());
+      expect(result.asLeft(), isA<OweRecordValidationFailure>());
+      expect(result.asLeft().cause, isA<DescriptionExceedsLimitFailure>());
     });
 
     test('When description is within the limit, it returns an OweRecord', () {
@@ -62,6 +64,17 @@ void main() {
       );
 
       expect(result.asRight(), isA<OweRecord>());
+    });
+
+    test('When copyWith sets an over-limit description, it returns a Left', () {
+      final record = buildOweRecord();
+
+      final result = record.copyWith(
+        description: 'a' * (DescriptionRules.maxLength + 1),
+      );
+
+      expect(result.asLeft(), isA<OweRecordValidationFailure>());
+      expect(result.asLeft().cause, isA<DescriptionExceedsLimitFailure>());
     });
   });
 

--- a/test/src/domain/use_cases/debtor/load_debtors_test.dart
+++ b/test/src/domain/use_cases/debtor/load_debtors_test.dart
@@ -2,6 +2,7 @@ import 'package:dartz/dartz.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:owe_me/src/core/error/failures/failures.dart';
+import 'package:owe_me/src/core/presentation/extensions/dartz_extensions.dart';
 import 'package:owe_me/src/domain/entities/debtor.dart';
 import 'package:owe_me/src/domain/value_objects/money.dart';
 import 'package:owe_me/src/domain/repositories/debtor_repository.dart';
@@ -22,11 +23,11 @@ void main() {
     test('should return a list of debtors when repository returns data', () async {
       // arrange
       final tDebtors = [
-        const Debtor(
+        Debtor.create(
           id: 1,
           nickname: 'Nickname',
-          totalDebt: Money(cents: 1000),
-        )
+          totalDebt: const Money(cents: 1000),
+        ).asRight()
       ];
 
       when(() => mockRepository.loadAllDebtors())

--- a/test/src/domain/validation/rules/description_rules_test.dart
+++ b/test/src/domain/validation/rules/description_rules_test.dart
@@ -1,0 +1,22 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:owe_me/src/domain/validation/failures/description_validation_failures.dart';
+import 'package:owe_me/src/domain/validation/rules/description_rules.dart';
+
+void main() {
+  group('DescriptionRules.validate', () {
+    test('When length is at the limit, it returns null', () {
+      final description = 'a' * DescriptionRules.maxLength; // exactly 100
+      expect(DescriptionRules.validate(description), isNull);
+    });
+
+    test(
+        'When length exceeds the limit, it returns DescriptionExceedsLimitFailure',
+        () {
+      final description = 'a' * (DescriptionRules.maxLength + 1); // 101
+      expect(
+        DescriptionRules.validate(description),
+        isA<DescriptionExceedsLimitFailure>(),
+      );
+    });
+  });
+}

--- a/test/src/domain/validation/rules/favorite_description_rules_test.dart
+++ b/test/src/domain/validation/rules/favorite_description_rules_test.dart
@@ -1,0 +1,40 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:owe_me/src/domain/failures/favorite_description_failures.dart';
+import 'package:owe_me/src/domain/validation/rules/description_rules.dart';
+import 'package:owe_me/src/domain/validation/rules/favorite_description_rules.dart';
+
+void main() {
+  group('FavoriteDescriptionRules.validate', () {
+    test('When description is empty, it returns FavoriteDescriptionEmptyFailure',
+        () {
+      expect(
+        FavoriteDescriptionRules.validate(''),
+        isA<FavoriteDescriptionEmptyFailure>(),
+      );
+    });
+
+    test(
+        'When description is whitespace-only, it returns FavoriteDescriptionEmptyFailure',
+        () {
+      expect(
+        FavoriteDescriptionRules.validate('   '),
+        isA<FavoriteDescriptionEmptyFailure>(),
+      );
+    });
+
+    test('When length is at the limit, it returns null', () {
+      final description = 'a' * DescriptionRules.maxLength; // exactly 100
+      expect(FavoriteDescriptionRules.validate(description), isNull);
+    });
+
+    test(
+        'When length exceeds the limit, it returns FavoriteDescriptionTooLongFailure',
+        () {
+      final description = 'a' * (DescriptionRules.maxLength + 1); // 101
+      expect(
+        FavoriteDescriptionRules.validate(description),
+        isA<FavoriteDescriptionTooLongFailure>(),
+      );
+    });
+  });
+}

--- a/test/src/domain/validation/rules/nickname_rules_test.dart
+++ b/test/src/domain/validation/rules/nickname_rules_test.dart
@@ -1,0 +1,35 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:owe_me/src/domain/validation/failures/nickname_validation_failures.dart';
+import 'package:owe_me/src/domain/validation/rules/nickname_rules.dart';
+
+void main() {
+  group('NicknameRules.validate', () {
+    test('When length is at the limit, it returns null', () {
+      final nickname = 'a' * NicknameRules.maxLength; // exactly 50
+      expect(NicknameRules.validate(nickname), isNull);
+    });
+
+    test('When length is empty, it returns NicknameEmptyFailure', () {
+      final nickname = '';
+      expect(
+        NicknameRules.validate(nickname),
+        isA<NicknameEmptyFailure>(),
+      );
+    });
+
+    test('When nickname is whitespace-only, it returns NicknameEmptyFailure',
+        () {
+      expect(NicknameRules.validate('   '), isA<NicknameEmptyFailure>());
+    });
+
+    test(
+        'When length exceeds the limit, it returns NicknameExceedsLimitFailure',
+        () {
+      final nickname = 'a' * (NicknameRules.maxLength + 1); // 51
+      expect(
+        NicknameRules.validate(nickname),
+        isA<NicknameExceedsLimitFailure>(),
+      );
+    });
+  });
+}


### PR DESCRIPTION
### Description

A batch of UI and validation improvements:

- **Length limits.** Adds separated validation rules classes as the single source
  of truth for field limits — `NicknameRules` (max 50) and `DescriptionRules`
  (max 100) — each referenced by both the domain and the `maxLength` UI cap.
  `FavoriteDescription` now validates through `FavoriteDescriptionRules` (its own
  empty rule + the shared length limit), replacing the old inline empty check.
  New failures are mapped to pt-BR.
- **Entity validation factories.** `Debtor.create` and `OweRecord.create` are
  `Either`-returning smart constructors (private constructors) that validate
  nickname / description through the rules classes. Construction sites and adapters
  route through them; adapters throw `DataIntegrityException` on invalid stored
  data. `copyWith` carries only invariant-preserving fields on both entities, so
  validated fields can only change through `create`.
- **Capitalized keyboards.** Nickname and description fields now open the keyboard
  capitalized (`words` / `sentences`).
- **List overflow fix.** Long debtor nicknames are wrapped in an `Expanded` so they
  no longer trigger a `RenderFlex` overflow in the home and selection list items.
- **Tooling.** VS Code dart format-on-save settings.

### Testing

`flutter analyze` clean, `flutter test` green (98 tests, including the new rules and
`create` validation tests).

### Notes / follow-ups

- No live per-keystroke validation on the length-limited fields — `maxLength`
  hard-caps input, so it isn't needed for length. Tracked separately as tech debt
  (switching the hard cap to live validation for better paste handling).
****